### PR TITLE
"failing" status is removed

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -18,9 +18,8 @@ class NotificationService:
             self.logger.info(trigger_message)
             return trigger_message, 200
 
-        fail_statuses = ["failing", "failed"]
         build_status = build.get("state")
-        if build_status not in fail_statuses:
+        if build_status != "failed":
             build_status_message = f"Not a build failure, no action taken for the build url={build_web_url}."
             return build_status_message, 200
 


### PR DESCRIPTION
Problem: Currently, if a build is failing and job allows to continue with next steps, 2 notifications are sent to build creator. 

Fix: `failing` is an intermediate status. Correct status is `failed` to send notification.  So `failing` status has been removed to check if build is failed or not. 

Reference: https://buildkite.com/docs/pipelines/defining-steps#build-states
